### PR TITLE
Bump kubescape version into v2.3.1

### DIFF
--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,3 +1,3 @@
 export const SCAN_CLUSTER_EVENT_NAME = "scanCluster";
-export const DEFAULT_KUBESCAPE_VERSION = "v2.0.176";
+export const DEFAULT_KUBESCAPE_VERSION = "v2.3.1";
 export const DEFAULT_KUBESCAPE_FRAMEWORKS = ["all"];


### PR DESCRIPTION
Tested when combined with https://github.com/kubescape/node-kubescape/pull/3 , scanning and error reporting are all OK.

![image](https://user-images.githubusercontent.com/43995067/236313906-84d9fcce-bdb0-4405-8033-f708beac126e.png)
![image](https://user-images.githubusercontent.com/43995067/236313812-6d4f38de-6a41-4aa1-b366-16cbbf421f7b.png)
